### PR TITLE
fix: add env_file option when build docker-compose

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,4 +41,4 @@ jobs:
             SLACK_CHANNEL_JIPHYEONJEON=${{ secrets.SLACK_CHANNEL_JIPHYEONJEON_DEV }}
             FRONT_URL=${{ secrets.FRONT_URL_LOCAL }}
             TOGETHER_HOME_URL=${{ secrets.TOGETHER_HOME_URL }}" > .env.dev
-            docker-compose up backend -d --build
+            docker-compose --env-file .env.dev up -d --build backend


### PR DESCRIPTION
#35 #36 

docker-compose 실행시 env_file 옵션을 주지 않아 빌드를 실패했었네요 🥲